### PR TITLE
Add scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.6, 2.12.14]
+        scala: [2.13.6, 2.12.14, 3.0.1]
         java: [adopt@1.8, adopt@1.11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -116,6 +116,16 @@ jobs:
           name: target-${{ matrix.os }}-2.12.14-${{ matrix.java }}
 
       - name: Inflate target directories (2.12.14)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.0.1)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.0.1-${{ matrix.java }}
+
+      - name: Inflate target directories (3.0.1)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/ci-release.sbt
+++ b/ci-release.sbt
@@ -1,5 +1,9 @@
 ThisBuild / scalaVersion := Dependencies.Versions.scala213
-ThisBuild / crossScalaVersions := Seq(Dependencies.Versions.scala213, Dependencies.Versions.scala212)
+ThisBuild / crossScalaVersions := Seq(
+  Dependencies.Versions.scala213,
+  Dependencies.Versions.scala212,
+  Dependencies.Versions.scala3
+)
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@1.11")
 

--- a/modules/newrelic-http-exporter/src/main/scala/io/janstenpickle/trace4cats/newrelic/Convert.scala
+++ b/modules/newrelic-http-exporter/src/main/scala/io/janstenpickle/trace4cats/newrelic/Convert.scala
@@ -4,7 +4,7 @@ import cats.Foldable
 import cats.syntax.foldable._
 import cats.syntax.show._
 import io.circe.syntax._
-import io.circe.{Encoder, Json, JsonObject}
+import io.circe.{Encoder, Json}
 import io.janstenpickle.trace4cats.`export`.SemanticTags
 import io.janstenpickle.trace4cats.model.{AttributeValue, Batch, CompletedSpan}
 
@@ -22,30 +22,26 @@ object Convert {
   }
 
   def attributesJson(attributes: Map[String, AttributeValue]): Json =
-    Json.fromJsonObject(JsonObject.fromMap(Map("attributes" -> attributes.asJson)))
+    Json.obj("attributes" := attributes.asJson)
 
   def spanJson(span: CompletedSpan): Json =
-    Json.fromJsonObject(
-      JsonObject.fromMap(
-        Map(
-          "trace.id" -> Json.fromString(span.context.traceId.show),
-          "id" -> Json.fromString(span.context.spanId.show),
-          "attributes" ->
-            attributesJson(
-              span.allAttributes ++ SemanticTags.kindTags(span.kind) ++ SemanticTags
-                .statusTags("")(span.status) ++ Map[String, AttributeValue](
-                "duration.ms" -> AttributeValue.LongValue(span.end.toEpochMilli - span.start.toEpochMilli),
-                "name" -> span.name
-              ) ++ span.context.parent.map { parent =>
-                "parent.id" -> AttributeValue.StringValue(parent.spanId.show)
-              }.toMap
-            )
+    Json.obj(
+      "trace.id" := span.context.traceId.show,
+      "id" := span.context.spanId.show,
+      "attributes" :=
+        attributesJson(
+          span.allAttributes ++ SemanticTags.kindTags(span.kind) ++ SemanticTags.statusTags("")(span.status) ++
+            Map[String, AttributeValue](
+              "duration.ms" -> AttributeValue.LongValue(span.end.toEpochMilli - span.start.toEpochMilli),
+              "name" -> span.name
+            ) ++ span.context.parent.map { parent =>
+              "parent.id" -> AttributeValue.StringValue(parent.spanId.show)
+            }.toMap
         )
-      )
     )
 
   def toJson[G[_]: Foldable](batch: Batch[G]): Json =
-    List(JsonObject.fromMap(Map("spans" -> Json.fromValues(batch.spans.foldLeft(ListBuffer.empty[Json]) { (buf, span) =>
+    List(Json.obj("spans" := batch.spans.foldLeft(ListBuffer.empty[Json]) { (buf, span) =>
       buf += spanJson(span)
-    })))).asJson
+    })).asJson
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val scala3 = "3.0.1"
 
     val trace4cats = "0.12.0-RC2+17-d73c7ff3"
-    val trace4catsExporterHttp = "0.12.0-RC2+4-5c079741"
+    val trace4catsExporterHttp = "0.12.0-RC2+4-69bfcea6"
 
     val circe = "0.14.1"
     val http4s = "0.23.0-RC1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,9 +4,10 @@ object Dependencies {
   object Versions {
     val scala212 = "2.12.14"
     val scala213 = "2.13.6"
+    val scala3 = "3.0.1"
 
-    val trace4cats = "0.12.0-RC2"
-    val trace4catsExporterHttp = "0.12.0-RC2"
+    val trace4cats = "0.12.0-RC2+17-d73c7ff3"
+    val trace4catsExporterHttp = "0.12.0-RC2+4-5c079741"
 
     val circe = "0.14.1"
     val http4s = "0.23.0-RC1"
@@ -20,10 +21,10 @@ object Dependencies {
   lazy val trace4catsModel = "io.janstenpickle"          %% "trace4cats-model"           % Versions.trace4cats
   lazy val trace4catsExporterHttp = "io.janstenpickle"   %% "trace4cats-exporter-http"   % Versions.trace4catsExporterHttp
 
-  lazy val circeGeneric = "io.circe"        %% "circe-generic-extras" % Versions.circe
-  lazy val circeParser = "io.circe"         %% "circe-parser"         % Versions.circe
-  lazy val http4sCirce = "org.http4s"       %% "http4s-circe"         % Versions.http4s
-  lazy val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client"  % Versions.http4s
+  lazy val circeGeneric = "io.circe"        %% "circe-core"          % Versions.circe
+  lazy val circeParser = "io.circe"         %% "circe-parser"        % Versions.circe
+  lazy val http4sCirce = "org.http4s"       %% "http4s-circe"        % Versions.http4s
+  lazy val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % Versions.http4s
 
   lazy val kindProjector = ("org.typelevel" % "kind-projector"     % Versions.kindProjector).cross(CrossVersion.full)
   lazy val betterMonadicFor = "com.olegpy" %% "better-monadic-for" % Versions.betterMonadicFor


### PR DESCRIPTION
Bases on https://github.com/trace4cats/trace4cats/pull/587

Includes some JSON encoding simplifications which I saw when checking for what circe modules are actually used. Entirely optional for Scala 3 purposes, the commit can be dropped as well.