### PR TITLE
Fix format for New Relic's JSON Payload

### DIFF
--- a/modules/newrelic-http-exporter/src/main/scala/io/janstenpickle/trace4cats/newrelic/Convert.scala
+++ b/modules/newrelic-http-exporter/src/main/scala/io/janstenpickle/trace4cats/newrelic/Convert.scala
@@ -22,7 +22,7 @@ object Convert {
   }
 
   def attributesJson(attributes: Map[String, AttributeValue]): Json =
-    Json.obj("attributes" := attributes.asJson)
+    attributes.asJson
 
   def spanJson(span: CompletedSpan): Json =
     Json.obj(


### PR DESCRIPTION
Hello! 

Thank you very much for this useful library. Prior to this change the payload would nest attributes (i.e. `"attributes": { "attributes: { /* data needed */} }`) causing the New Relic UI to not show any distributed traces for this application. 

Now this works as intended 😸 
![image](https://user-images.githubusercontent.com/14280155/149835123-f739cdb4-3611-4184-9b47-fa90fb322d3c.png)
